### PR TITLE
Add a graphs controller.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,8 @@ group :development do
   gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'annotate', '~> 2.7'
   gem 'rails-erd', '~> 1.5', require: false
+  gem 'better_errors'
+  gem 'binding_of_caller'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,7 +52,13 @@ GEM
     arel (9.0.0)
     autoprefixer-rails (8.3.0)
       execjs
+    better_errors (2.4.0)
+      coderay (>= 1.0.0)
+      erubi (>= 1.0.0)
+      rack (>= 0.9.0)
     bindex (0.5.0)
+    binding_of_caller (0.8.0)
+      debug_inspector (>= 0.0.1)
     bootsnap (1.3.0)
       msgpack (~> 1.0)
     bootstrap (4.1.0)
@@ -75,9 +81,11 @@ GEM
     chromedriver-helper (1.2.0)
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
+    coderay (1.1.2)
     concurrent-ruby (1.0.5)
     crass (1.0.4)
     database_cleaner (1.7.0)
+    debug_inspector (0.0.3)
     erubi (1.7.1)
     execjs (2.7.0)
     ffi (1.9.23)
@@ -224,6 +232,8 @@ PLATFORMS
 
 DEPENDENCIES
   annotate (~> 2.7)
+  better_errors
+  binding_of_caller
   bootsnap (>= 1.1.0)
   bootstrap (~> 4.1.0)
   byebug

--- a/README.md
+++ b/README.md
@@ -85,4 +85,3 @@ To view all dependencies used in this project, see the [`Gemfile`](/Gemfile) and
 - Implement visualizations using the dataset.
 - Implement caching, the data is static so this should be fairly easy (famous last words).
 - Figure out how to handle data for the browser when there's more than one `version_added` statement, or when there are `flags` or `notes`.
-- Create a much smaller subset of the existing JSON data for testing correctness of SQL queries.

--- a/README.md
+++ b/README.md
@@ -85,3 +85,4 @@ To view all dependencies used in this project, see the [`Gemfile`](/Gemfile) and
 - Implement visualizations using the dataset.
 - Implement caching, the data is static so this should be fairly easy (famous last words).
 - Figure out how to handle data for the browser when there's more than one `version_added` statement, or when there are `flags` or `notes`.
+- Create a much smaller subset of the existing JSON data for testing correctness of SQL queries.

--- a/app/assets/javascripts/graphs.js
+++ b/app/assets/javascripts/graphs.js
@@ -1,0 +1,2 @@
+// Place all the behaviors and hooks related to the matching controller here.
+// All this logic will automatically be available in application.js.

--- a/app/assets/stylesheets/graphs.scss
+++ b/app/assets/stylesheets/graphs.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Graphs controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/graphs_controller.rb
+++ b/app/controllers/graphs_controller.rb
@@ -15,11 +15,8 @@ class GraphsController < ApplicationController
       @browser_stats[browser] = stats
       
       total = 0
-      puts "#{browser}"
       @browser_stats[browser].each do |key, value|
-        puts "Key: #{key}, Val: #{value}"
         total += value
-        puts "total: #{total}"
       end
 
       @browser_stats[browser][:total] = total

--- a/app/controllers/graphs_controller.rb
+++ b/app/controllers/graphs_controller.rb
@@ -3,13 +3,15 @@ class GraphsController < ApplicationController
     @chrome_stats = {
       unknown: Feature.chrome_nil.count,
       yes: Feature.chrome_true.count,
-      no: Feature.chrome_false.count
+      no: Feature.chrome_false.count,
+      no_data: Feature.chrome_no_data.count
     }
 
     @firefox_stats = {
       unknown: Feature.firefox_nil.count,
       yes: Feature.firefox_true.count,
-      no: Feature.firefox_false.count
+      no: Feature.firefox_false.count,
+      no_data: Feature.firefox_no_data.count
     }
 
     @feature_count = Feature.all.count

--- a/app/controllers/graphs_controller.rb
+++ b/app/controllers/graphs_controller.rb
@@ -2,7 +2,9 @@ class GraphsController < ApplicationController
   def index
     @browser_stats = Hash.new
 
-    [:chrome, :firefox].each do |browser|
+    @browsers = Rails.configuration.browsers
+
+    @browsers.keys.each do |browser|
       stats = {
         unknown: Feature.public_send("#{browser}_nil").count,
         yes: Feature.public_send("#{browser}_true").count,
@@ -11,6 +13,16 @@ class GraphsController < ApplicationController
       }
 
       @browser_stats[browser] = stats
+      
+      total = 0
+      puts "#{browser}"
+      @browser_stats[browser].each do |key, value|
+        puts "Key: #{key}, Val: #{value}"
+        total += value
+        puts "total: #{total}"
+      end
+
+      @browser_stats[browser][:total] = total
     end
 
     @feature_count = Feature.all.count

--- a/app/controllers/graphs_controller.rb
+++ b/app/controllers/graphs_controller.rb
@@ -1,18 +1,17 @@
 class GraphsController < ApplicationController
   def index
-    @chrome_stats = {
-      unknown: Feature.chrome_nil.count,
-      yes: Feature.chrome_true.count,
-      no: Feature.chrome_false.count,
-      no_data: Feature.chrome_no_data.count
-    }
+    @browser_stats = Hash.new
 
-    @firefox_stats = {
-      unknown: Feature.firefox_nil.count,
-      yes: Feature.firefox_true.count,
-      no: Feature.firefox_false.count,
-      no_data: Feature.firefox_no_data.count
-    }
+    [:chrome, :firefox].each do |browser|
+      stats = {
+        unknown: Feature.public_send("#{browser}_nil").count,
+        yes: Feature.public_send("#{browser}_true").count,
+        no: Feature.public_send("#{browser}_false").count,
+        no_data: Feature.public_send("#{browser}_no_data").count
+      }
+
+      @browser_stats["#{browser}".to_sym] = stats
+    end
 
     @feature_count = Feature.all.count
   end

--- a/app/controllers/graphs_controller.rb
+++ b/app/controllers/graphs_controller.rb
@@ -10,7 +10,7 @@ class GraphsController < ApplicationController
         no_data: Feature.public_send("#{browser}_no_data").count
       }
 
-      @browser_stats["#{browser}".to_sym] = stats
+      @browser_stats[browser] = stats
     end
 
     @feature_count = Feature.all.count

--- a/app/controllers/graphs_controller.rb
+++ b/app/controllers/graphs_controller.rb
@@ -1,0 +1,17 @@
+class GraphsController < ApplicationController
+  def index
+    @chrome_stats = {
+      unknown: Feature.chrome_nil.count,
+      yes: Feature.chrome_true.count,
+      no: Feature.chrome_false.count
+    }
+
+    @firefox_stats = {
+      unknown: Feature.firefox_nil.count,
+      yes: Feature.firefox_true.count,
+      no: Feature.firefox_false.count
+    }
+
+    @feature_count = Feature.all.count
+  end
+end

--- a/app/helpers/graphs_helper.rb
+++ b/app/helpers/graphs_helper.rb
@@ -1,0 +1,2 @@
+module GraphsHelper
+end

--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -68,4 +68,36 @@ class Feature < ApplicationRecord
       tsearch: { prefix: true },
       trigram: { threshold: 0.3 }
     }
+
+  def self.chrome_nil
+    where(chrome: {"version_added": nil})
+  end
+
+  def self.chrome_false
+    where(chrome: {"version_added": false})
+  end
+
+  def self.chrome_true
+    # Find all entries which are true or have a version number string.
+    where.not(
+      chrome: {"version_added": false},
+      chrome: {"version_added": nil}
+    )
+  end
+
+  def self.firefox_nil
+    where(firefox: {"version_added": nil})
+  end
+
+  def self.firefox_false
+    where(firefox: {"version_added": false})
+  end
+
+  def self.firefox_true
+    # Find all entries which are true or have a version number string.
+    where.not(
+      firefox: {"version_added": false},
+      firefox: {"version_added": nil}
+    )
+  end
 end

--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -64,7 +64,7 @@ class Feature < ApplicationRecord
       trigram: { threshold: 0.3 }
     }
 
-  [:firefox, :chrome].each do |browser|
+  Rails.configuration.browsers.keys.each do |browser|
     scope "#{browser}_false", -> { where( "#{browser}": {"version_added": false} ) }
 
     scope "#{browser}_nil", -> { where( "#{browser}": {"version_added": nil} ) }
@@ -77,7 +77,7 @@ class Feature < ApplicationRecord
     scope "#{browser}_true", -> {
       where("#{browser} ->> :key ~ :regex",
             key: "version_added",
-            regex: '^(\d+\.)?(\d+\.)?(\*|\d+)$'
+            regex: '^(?!true|false|null)'
            )
         .or(where("#{browser}": {"version_added": true}))
     }

--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -52,15 +52,10 @@ class Feature < ApplicationRecord
   scope :no_experimental_info,     -> { where(experimental: nil) }
   
   # Feature category scopes
-  scope :api,           -> { where("name ~* ?", '^api.*') }
-  scope :css,           -> { where("name ~* ?", '^css.*') }
-  scope :html,          -> { where("name ~* ?", '^html.*') }
-  scope :http,          -> { where("name ~* ?", '^http.*') }
-  scope :javascript,    -> { where("name ~* ?", '^javascript.*') }
-  scope :mathml,        -> { where("name ~* ?", '^mathml.*') }
-  scope :svg,           -> { where("name ~* ?", '^svg.*') }
-  scope :webdriver,     -> { where("name ~* ?", '^webdriver.*') }
-  scope :webextensions, -> { where("name ~* ?", '^webextensions.*') }
+  # Creates scopes like Feature.api, Feature.css, Feature.html, etc.
+  Rails.configuration.feature_categories.keys.each do |category|
+    scope "#{category}", -> { where("name ~* ?", "^#{category}.*") }
+  end 
 
   pg_search_scope :search,
     against: [:name],

--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -65,15 +65,16 @@ class Feature < ApplicationRecord
     }
 
   Rails.configuration.browsers.keys.each do |browser|
-    scope "#{browser}_false", -> { where( "#{browser}": {"version_added": false} ) }
+    scope "#{browser}_false", -> { where( "#{browser} ->> 'version_added' ~ 'false'") }
 
     scope "#{browser}_nil", -> { where( "#{browser}": {"version_added": nil} ) }
 
     scope "#{browser}_no_data", -> { where("#{browser}": nil) }
 
     # This tries to find all cases where the version_added value is either
-    # version number or true.
-    # This code is bad, but it's also probably the best you're gonna get.
+    # version number or true, since the version_added can only be true, false,
+    # null, or a version number we can use a regex to elimate all but the
+    # version numbers.
     scope "#{browser}_true", -> {
       where("#{browser} ->> :key ~ :regex",
             key: "version_added",

--- a/app/views/graphs/index.html.erb
+++ b/app/views/graphs/index.html.erb
@@ -14,7 +14,8 @@
               {
                 "Unknown" => @chrome_stats[:unknown],
                 "True" => @chrome_stats[:yes],
-                "False" => @chrome_stats[:no]
+                "False" => @chrome_stats[:no],
+                "No data" => @chrome_stats[:no_data]
               },
               title: "Chrome",
               donut: true
@@ -27,7 +28,8 @@
               {
                 "Unknown" => @firefox_stats[:unknown],
                 "True" => @firefox_stats[:yes],
-                "False" => @firefox_stats[:no]
+                "False" => @firefox_stats[:no],
+                "No data" => @firefox_stats[:no_data]
               },
               title: "Firefox",
               donut: true

--- a/app/views/graphs/index.html.erb
+++ b/app/views/graphs/index.html.erb
@@ -8,7 +8,7 @@
   <div class="row">
     <div class="col-12">
       <div class="card-columns">
-        <% [:chrome, :firefox].each do |browser| %>
+        <% @browsers.keys.each do |browser| %>
           <div class="card">
             <div class="card-body">
               <%= pie_chart(
@@ -18,10 +18,27 @@
                   "False" => @browser_stats[browser][:no],
                   "No data" => @browser_stats[browser][:no_data]
                 },
-                title: "#{browser}",
+                title: @browsers[browser],
                 donut: true
               ) %>
             </div>
+            <ul class="list-group list-group-flush">
+              <li class="list-group-item">
+                Unknown: <%= @browser_stats[browser][:unknown] %>
+              </li>
+              <li class="list-group-item">
+                True: <%= @browser_stats[browser][:yes] %>
+              </li>
+              <li class="list-group-item">
+                False: <%= @browser_stats[browser][:no] %>
+              </li>
+              <li class="list-group-item">
+                No data: <%= @browser_stats[browser][:no_data] %>
+              </li>
+              <li class="list-group-item">
+                Total: <%= @browser_stats[browser][:total] %>
+              </li>
+            </ul>
           </div>
         <% end %>
       </div>

--- a/app/views/graphs/index.html.erb
+++ b/app/views/graphs/index.html.erb
@@ -12,10 +12,10 @@
           <div class="card-body">
             <%= pie_chart(
               {
-                "Unknown" => @chrome_stats[:unknown],
-                "True" => @chrome_stats[:yes],
-                "False" => @chrome_stats[:no],
-                "No data" => @chrome_stats[:no_data]
+                "Unknown" => @browser_stats[:chrome][:unknown],
+                "True" => @browser_stats[:chrome][:yes],
+                "False" => @browser_stats[:chrome][:no],
+                "No data" => @browser_stats[:chrome][:no_data]
               },
               title: "Chrome",
               donut: true
@@ -26,10 +26,10 @@
           <div class="card-body">
             <%= pie_chart(
               {
-                "Unknown" => @firefox_stats[:unknown],
-                "True" => @firefox_stats[:yes],
-                "False" => @firefox_stats[:no],
-                "No data" => @firefox_stats[:no_data]
+                "Unknown" => @browser_stats[:firefox][:unknown],
+                "True" => @browser_stats[:firefox][:yes],
+                "False" => @browser_stats[:firefox][:no],
+                "No data" => @browser_stats[:firefox][:no_data]
               },
               title: "Firefox",
               donut: true

--- a/app/views/graphs/index.html.erb
+++ b/app/views/graphs/index.html.erb
@@ -8,34 +8,22 @@
   <div class="row">
     <div class="col-12">
       <div class="card-columns">
-        <div class="card">
-          <div class="card-body">
-            <%= pie_chart(
-              {
-                "Unknown" => @browser_stats[:chrome][:unknown],
-                "True" => @browser_stats[:chrome][:yes],
-                "False" => @browser_stats[:chrome][:no],
-                "No data" => @browser_stats[:chrome][:no_data]
-              },
-              title: "Chrome",
-              donut: true
-            ) %>
+        <% [:chrome, :firefox].each do |browser| %>
+          <div class="card">
+            <div class="card-body">
+              <%= pie_chart(
+                {
+                  "Unknown" => @browser_stats[browser][:unknown],
+                  "True" => @browser_stats[browser][:yes],
+                  "False" => @browser_stats[browser][:no],
+                  "No data" => @browser_stats[browser][:no_data]
+                },
+                title: "#{browser}",
+                donut: true
+              ) %>
+            </div>
           </div>
-        </div>
-        <div class="card">
-          <div class="card-body">
-            <%= pie_chart(
-              {
-                "Unknown" => @browser_stats[:firefox][:unknown],
-                "True" => @browser_stats[:firefox][:yes],
-                "False" => @browser_stats[:firefox][:no],
-                "No data" => @browser_stats[:firefox][:no_data]
-              },
-              title: "Firefox",
-              donut: true
-            ) %>
-          </div>
-        </div>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/graphs/index.html.erb
+++ b/app/views/graphs/index.html.erb
@@ -1,0 +1,40 @@
+<div class="container">
+  <div class="row py-4">
+    <div class="col-12">
+      <h1>Graphs</h1>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-12">
+      <div class="card-columns">
+        <div class="card">
+          <div class="card-body">
+            <%= pie_chart(
+              {
+                "Unknown" => @chrome_stats[:unknown],
+                "True" => @chrome_stats[:yes],
+                "False" => @chrome_stats[:no]
+              },
+              title: "Chrome",
+              donut: true
+            ) %>
+          </div>
+        </div>
+        <div class="card">
+          <div class="card-body">
+            <%= pie_chart(
+              {
+                "Unknown" => @firefox_stats[:unknown],
+                "True" => @firefox_stats[:yes],
+                "False" => @firefox_stats[:no]
+              },
+              title: "Firefox",
+              donut: true
+            ) %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -12,6 +12,9 @@
       <li class="nav-item">
         <%= active_link_to "Features", features_path, class: "nav-link" %>
       </li>
+      <li class="nav-item">
+        <%= active_link_to "Graphs", graphs_path, class: "nav-link" %>
+      </li>
     </ul>
   </div>
 </nav>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -6,60 +6,19 @@
   </div>
 
   <div class="row">
-    <div class="col-12">
-      <div class="card-columns">
-        <div class="card">
-          <div class="card-header">
-            Statistics
-          </div>
-          <ul class="list-group list-group-flush">
-            <li class="list-group-item">Features: <%= @feature_count %></li>
-            <li class="list-group-item">Features with an MDN link: <%= @features_with_mdn_count %></li>
-            <li class="list-group-item">Features with a description: <%= @features_with_description_count %></li>
-            <li class="list-group-item">Features on a standards track: <%= @standard_features %></li>
-            <li class="list-group-item">Features marked experimental: <%= @experimental_features %></li>
-            <li class="list-group-item">Features marked deprecated: <%= @deprecated_features %></li>
-          </ul>
+    <div class="col-12 col-md-4">
+      <div class="card">
+        <div class="card-header">
+          Statistics
         </div>
-
-        <div class="card">
-          <div class="card-body">
-            <%= pie_chart(
-              {
-                "True" => @experimental_features,
-                "False" => @feature_count - @experimental_features
-              },
-              title: "Experimental features",
-              donut: true
-            ) %>
-          </div>
-        </div>
-
-        <div class="card">
-          <div class="card-body">
-            <%= pie_chart(
-              {
-                "True" => @features_with_mdn_count,
-                "False" => @feature_count - @features_with_mdn_count
-              },
-              title: "Features with MDN Links",
-              donut: true
-            ) %>
-          </div>
-        </div>
-
-        <div class="card">
-          <div class="card-body">
-            <%= pie_chart(
-              {
-                "True" => @features_with_description_count,
-                "False" => @feature_count - @features_with_description_count
-              },
-              title: "Features with a description",
-              donut: true
-            ) %>
-          </div>
-        </div>
+        <ul class="list-group list-group-flush">
+          <li class="list-group-item">Features: <%= @feature_count %></li>
+          <li class="list-group-item">Features with an MDN link: <%= @features_with_mdn_count %></li>
+          <li class="list-group-item">Features with a description: <%= @features_with_description_count %></li>
+          <li class="list-group-item">Features on a standards track: <%= @standard_features %></li>
+          <li class="list-group-item">Features marked experimental: <%= @experimental_features %></li>
+          <li class="list-group-item">Features marked deprecated: <%= @deprecated_features %></li>
+        </ul>
       </div>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
 
   match 'features', to: 'features#index', via: :get
   match 'browsers', to: 'browsers#index', via: :get
+  match 'graphs', to: 'graphs#index', via: :get
 
   root 'welcome#index'
 end

--- a/db/migrate/20180426202826_change_browser_columns_default.rb
+++ b/db/migrate/20180426202826_change_browser_columns_default.rb
@@ -1,0 +1,20 @@
+class ChangeBrowserColumnsDefault < ActiveRecord::Migration[5.2]
+  def change
+    change_column_default :features, :chrome, from: '{}', to: nil
+    change_column_default :features, :chrome_android, from: '{}', to: nil
+    change_column_default :features, :edge, from: '{}', to: nil
+    change_column_default :features, :edge_mobile, from: '{}', to: nil
+    change_column_default :features, :firefox, from: '{}', to: nil
+    change_column_default :features, :firefox_android, from: '{}', to: nil
+    change_column_default :features, :ie, from: '{}', to: nil
+    change_column_default :features, :nodejs, from: '{}', to: nil
+    change_column_default :features, :opera, from: '{}', to: nil
+    change_column_default :features, :qq_android, from: '{}', to: nil
+    change_column_default :features, :safari, from: '{}', to: nil
+    change_column_default :features, :safari_ios, from: '{}', to: nil
+    change_column_default :features, :samsunginternet_android, from: '{}', to: nil
+    change_column_default :features, :uc_android, from: '{}', to: nil
+    change_column_default :features, :uc_chinese_android, from: '{}', to: nil
+    change_column_default :features, :webview_android, from: '{}', to: nil
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,7 +11,7 @@ require 'database_cleaner'
 
 puts "Seeding..."
 
-if Rails.env.test? 
+if Rails.env.test?
   puts "Rails environment is test"
 end
 
@@ -24,7 +24,7 @@ DatabaseCleaner.allow_remote_database_url = true
 DatabaseCleaner.strategy = :truncation
 DatabaseCleaner.clean
 
-if Rails.env.test?
+if Rails.env.test? || ENV['USE_TEST_DATA']
   @data = File.read('public/data-test.json')
 else
   @data = File.read('public/data.json')
@@ -45,7 +45,7 @@ end
 #   webextensions: []
 # }
 
-if Rails.env.test?
+if Rails.env.test? || ENV['USE_TEST_DATA']
   @top_level_schema = {
     css: []
   }
@@ -63,7 +63,7 @@ else
   }
 end
 
-if Rails.env.test?
+if Rails.env.test? || ENV['USE_TEST_DATA']
   @browser_names = {
     firefox: "Firefox"
   }

--- a/public/data-test.json
+++ b/public/data-test.json
@@ -14,7 +14,7 @@
     "bare_feature": {
       "__compat": {
         "support": {
-          "firefox": {
+          "chrome": {
             "version_added": "1"
           }
         }

--- a/public/data-test.json
+++ b/public/data-test.json
@@ -14,7 +14,7 @@
     "bare_feature": {
       "__compat": {
         "support": {
-          "chrome": {
+          "firefox": {
             "version_added": "1"
           }
         }
@@ -61,6 +61,25 @@
         "support": {
           "firefox": {
             "version_added": "1"
+          }
+        }
+      }
+    },
+    "feature_with_no_firefox_data": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "1"
+          }
+        }
+      }
+    },
+    "feature_with_alternative_name": {
+      "__compat": {
+        "support": {
+          "firefox": {
+            "version_added": false,
+            "alternative_name": "feature_with_firefox_alternative_name"
           }
         }
       }

--- a/public/data-test.json
+++ b/public/data-test.json
@@ -78,7 +78,7 @@
       "__compat": {
         "support": {
           "firefox": {
-            "version_added": false,
+            "version_added": true,
             "alternative_name": "feature_with_firefox_alternative_name"
           }
         }
@@ -86,7 +86,7 @@
     },
     "standard_feature_with_description": {
       "__compat": {
-        "description": "This will be 'Basic support' regardless",
+        "description": "Lorem ipsum",
         "support": {
           "firefox": {
             "version_added": "1"
@@ -98,7 +98,7 @@
       },
       "subfeature_with_description": {
         "__compat": {
-          "description": "<code>Interface()</code> constructor",
+          "description": "Lorem ipsum",
           "support": {
             "firefox": {
               "version_added": "1"
@@ -109,7 +109,7 @@
     },
     "nonstandard_feature_with_description": {
       "__compat": {
-        "description": "This will be 'Basic support' regardless",
+        "description": "Lorem ipsum",
         "support": {
           "firefox": {
             "version_added": "1"
@@ -143,7 +143,7 @@
     "feature_with_mdn_url_and_description": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy",
-        "description": "CSP",
+        "description": "Lorem ipsum",
         "support": {
           "firefox": {
             "version_added": "1"
@@ -153,7 +153,7 @@
       "subfeature_with_mdn_url_and_description": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/child-src",
-          "description": "CSP: child-src",
+          "description": "Lorem ipsum",
           "support": {
             "firefox": {
               "version_added": "1"
@@ -205,7 +205,7 @@
       },
       "deprecated_subfeature_with_description": {
         "__compat": {
-          "description": "Deprecated syntax",
+          "description": "Lorem ipsum",
           "support": {
             "firefox": {
               "version_added": "1"

--- a/test/controllers/graphs_controller_test.rb
+++ b/test/controllers/graphs_controller_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class GraphsControllerTest < ActionDispatch::IntegrationTest
   test "should get index" do
-    get graphs_index_url
+    get graphs_url
     assert_response :success
   end
 

--- a/test/controllers/graphs_controller_test.rb
+++ b/test/controllers/graphs_controller_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class GraphsControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get graphs_index_url
+    assert_response :success
+  end
+
+end


### PR DESCRIPTION
- Adds better_errors gem
- Adds the ability to run `USE_TEST_DATA=true bundle exec rake db:seed` in order to run the application in development mode with the test data.
- Changes the default value for the browser columns in the feature table to `nil` instead of `'{}'`
- Adds graphs pages

TODO:
- The graph values don't quite add up when there are more complex browser support objects, e.g. it handles `{ version_added: true }` but I'm not 100% sure it handles `{ version_added: true, prefix: '-webkit'}` and it _definitely_ doesn't handle support objects that are arrays of these hashes.