### PR TITLE
Add search

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem 'version_sorter', '~> 2.2'
 gem 'kaminari', '~> 1.1'
 
 gem 'octicons_helper'
+gem 'pg_search'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,10 @@ GEM
       octicons (= 5.3.0)
       rails
     pg (1.0.0)
+    pg_search (2.1.2)
+      activerecord (>= 4.2)
+      activesupport (>= 4.2)
+      arel (>= 6)
     popper_js (1.12.9)
     public_suffix (3.0.2)
     puma (3.11.4)
@@ -221,6 +225,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   octicons_helper
   pg (~> 1.0)
+  pg_search
   puma (~> 3.11)
   rails (~> 5.2.0)
   sass-rails (~> 5.0)

--- a/app/controllers/features_controller.rb
+++ b/app/controllers/features_controller.rb
@@ -41,6 +41,8 @@ class FeaturesController < ApplicationController
     @features = Feature.all.page params[:page]
     @feature_count = Feature.all.count
     @browsers = BROWSERS_PLUS_NODE
+    
+    @search = true
   end
 
   def api
@@ -95,5 +97,18 @@ class FeaturesController < ApplicationController
     @features = Feature.where("name ~* ?", '^webextensions.*').page params[:page]
     @feature_count = Feature.where("name ~* ?", '^webextensions.*').count
     @browsers = BROWSERS
+  end
+
+  def search
+    if params[:query].present?
+      @features = Feature.search(params[:query]).page(params[:page])
+    else
+      @features = Feature.none.page(params[:page])
+    end
+
+    @browsers = BROWSERS_PLUS_NODE
+
+    @search_page = true
+    @search = true
   end
 end

--- a/app/controllers/features_controller.rb
+++ b/app/controllers/features_controller.rb
@@ -103,7 +103,7 @@ class FeaturesController < ApplicationController
     if params[:query].present?
       @features = Feature.search(params[:query]).page(params[:page])
     else
-      @features = Feature.none.page(params[:page])
+      @features = Feature.all.page(params[:page])
     end
 
     @browsers = BROWSERS_PLUS_NODE

--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -1,5 +1,14 @@
 class Feature < ApplicationRecord
+  include PgSearch
+
   validates :name, presence: true, uniqueness: true
 
   paginates_per 50
+
+  pg_search_scope :search,
+    against: [:name],
+    using: {
+      tsearch: { prefix: true },
+      trigram: { threshold: 0.3 }
+    }
 end

--- a/app/views/features/_feature_layout.html.erb
+++ b/app/views/features/_feature_layout.html.erb
@@ -3,12 +3,21 @@
     <%= render 'features_navigation' %>
   </div>
 
+  <% if @search %>
+    <%= form_tag("/features/search", method: "get") do %>
+      <%= text_field_tag(:query) %>
+      <%= submit_tag("Search") %>
+    <% end %>
+  <% end %>
+
   <div class="row">
     <h1><%= title %></h1>
   </div>
 
   <div class="row">
-    <p>Features tracked: <%= @feature_count %></p>
+    <% unless @search_page %>
+      <p>Features tracked: <%= @feature_count %></p>
+    <% end %>
 
     <% unless defined?(include_node) %>
       <% include_node = false %>

--- a/app/views/features/_feature_layout.html.erb
+++ b/app/views/features/_feature_layout.html.erb
@@ -6,7 +6,7 @@
   <% if @search %>
     <%= form_tag("/features/search", method: "get") do %>
       <%= text_field_tag(:query) %>
-      <%= submit_tag("Search") %>
+      <%= submit_tag("Search", class: "btn btn-default") %>
     <% end %>
   <% end %>
 

--- a/app/views/features/_features_list.html.erb
+++ b/app/views/features/_features_list.html.erb
@@ -61,4 +61,8 @@
   </div>
 <% end %>
 
+<% if features.count == 0 %>
+  No features found.
+<% end %>
+
 <%= paginate features %>

--- a/app/views/features/_features_navigation.html.erb
+++ b/app/views/features/_features_navigation.html.erb
@@ -1,5 +1,6 @@
 <nav class="nav nav-pills nav-fill flex-fill flex-column flex-md-row">
   <%= active_link_to "All", features_path, class: "nav-item nav-link" %>
+  <%= active_link_to "Search", features_search_path, class: "nav-item nav-link" %>
   <%= active_link_to "API", features_api_path, class: "nav-item nav-link" %>
   <%= active_link_to "CSS", features_css_path, class: "nav-item nav-link" %>
   <%= active_link_to "HTML", features_html_path, class: "nav-item nav-link" %>

--- a/app/views/features/search.html.erb
+++ b/app/views/features/search.html.erb
@@ -1,0 +1,4 @@
+<div class="container">
+
+  <%= render 'feature_layout', title: "Search Features", include_node: true %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,8 @@ Rails.application.routes.draw do
   get '/features/svg', to: 'features#svg'
   get '/features/webdriver', to: 'features#webdriver'
   get '/features/webextensions', to: 'features#webextensions'
+  
+  get '/features/search', to: 'features#search'
 
   root 'welcome#index'
 end

--- a/db/migrate/20180423232646_add_pg_trgm_extension_to_db.rb
+++ b/db/migrate/20180423232646_add_pg_trgm_extension_to_db.rb
@@ -1,0 +1,5 @@
+class AddPgTrgmExtensionToDb < ActiveRecord::Migration[5.2]
+  def change
+    execute "create extension pg_trgm;"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_04_17_023133) do
+ActiveRecord::Schema.define(version: 2018_04_23_232646) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_trgm"
   enable_extension "plpgsql"
 
   create_table "browsers", force: :cascade do |t|


### PR DESCRIPTION
Resolves #15.

Crappy search, but it works pretty well for basic stuff.

This should be followed-up with a change to the way the Features page works. Rather than having dedicated pages for each feature category, just make the feature categories available as filters for the search.

<img width="1435" alt="screen shot 2018-04-23 at 6 01 23 pm" src="https://user-images.githubusercontent.com/2977353/39159037-a0119102-4720-11e8-8de3-fc4898ac7dec.png">
