### PR TITLE
Add additional data to browser support tables

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,8 +14,11 @@
 //= require jquery3
 //= require Chart.bundle
 //= require chartkick
+//= require popper
 //= require bootstrap/util
 //= require bootstrap/collapse
+//= require bootstrap/tooltip
+//= require bootstrap/popover
 //= require ready
 //= require_tree .
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,5 +16,6 @@
 //= require chartkick
 //= require bootstrap/util
 //= require bootstrap/collapse
+//= require ready
 //= require_tree .
 

--- a/app/assets/javascripts/features.js
+++ b/app/assets/javascripts/features.js
@@ -26,6 +26,7 @@ function parseHashSupportObject(json, item) {
   jsonKeys = Object.keys(json);
   if (jsonKeys.length > 1) {
     item.dataset.toggle = "popover";
+    item.classList.add('more-info-available');
   } else {
     return;
   }
@@ -47,7 +48,7 @@ function parseHashSupportObject(json, item) {
   }
   
   if (jsonKeys.includes('alternative_name')) {
-    contentForPopover.set("Alternative Name", json.alternative_name);
+    contentForPopover.set("Alternative Name", "<code>" + json.alternative_name + "</code>");
   }
 
   if (jsonKeys.includes('prefix')) {

--- a/app/assets/javascripts/features.js
+++ b/app/assets/javascripts/features.js
@@ -1,7 +1,6 @@
 function browserSupportParser() {
   // Returns an HTMLCollection
   let supportInfoElements = document.getElementsByClassName('browser-support-info');
-  // console.log(supportInfoElements);
 
   for (var i = 0; i < supportInfoElements.length; i++) {
     let json = supportInfoElements.item(i).dataset.supportJson;
@@ -25,25 +24,42 @@ function browserSupportParser() {
 
 function parseHashSupportObject(json, item) {
   jsonKeys = Object.keys(json);
-  console.log(item);
-  item.textContent = "butts";
-  item.dataset.test = "butts";
-  item.dataset.toggle = "popover";
-  item.dataset.trigger = "focus";
+  if (jsonKeys.length > 1) {
+    item.dataset.toggle = "popover";
+  } else {
+    return;
+  }
+
   item.dataset.title = "More details";
-  item.dataset.content = "details";
 
-  console.log(json.version_added);
-  console.log(json.alternative_name);
+  let contentForPopover = new Map();
 
-  possibleKeys = [
-    "version_added",
-    "version_removed",
-    "flags",
-    "notes",
-    "prefix",
-    "partial_implementation"
-  ];
+  if (jsonKeys.includes('partial_implementation')) {
+    contentForPopover.set("Partial implementation", "This is a partial implementation.");
+  }
+
+  if (jsonKeys.includes('notes')) {
+    if (Array.isArray(json.notes)) {
+      contentForPopover.set("Notes", json.notes.join("<br>"));
+    } else {
+      contentForPopover.set("Notes", json.notes);
+    }
+  }
+  
+  if (jsonKeys.includes('alternative_name')) {
+    contentForPopover.set("Alternative Name", json.alternative_name);
+  }
+
+  if (jsonKeys.includes('prefix')) {
+    contentForPopover.set("Requires the vendor prefix", "<code>" + json.prefix + "</code>");
+  }
+
+  contentForPopoverHtml = "";
+  for (var [key, value] of contentForPopover.entries()) {
+    contentForPopoverHtml += '<p>' + key + ': ' + value + '</p>';
+  }
+
+  item.dataset.content = contentForPopoverHtml;
 }
 
 function parseArraySupportObject(json) {
@@ -54,6 +70,8 @@ ready(function () {
   browserSupportParser();
   $('body').popover({
     container: 'body',
-    selector: '[data-toggle="popover"]'
+    html: true,
+    selector: '[data-toggle="popover"]',
+    template: '<div class="popover" role="tooltip"> <div class="arrow"></div> <h3 class="popover-header"></h3> <div class="popover-body"></div></div>'
   })
 });

--- a/app/assets/javascripts/features.js
+++ b/app/assets/javascripts/features.js
@@ -55,6 +55,14 @@ function parseHashSupportObject(json, item) {
     contentForPopover.set("Requires the vendor prefix", "<code>" + json.prefix + "</code>");
   }
 
+  if (jsonKeys.includes('flags')) {
+    contentForPopover.set("Flags", json.flags);
+  }
+
+  if (jsonKeys.includes('version_removed')) {
+    contentForPopover.set("Version removed", json.version_removed);
+  }
+
   contentForPopoverHtml = "";
   for (var [key, value] of contentForPopover.entries()) {
     contentForPopoverHtml += '<p>' + key + ': ' + value + '</p>';

--- a/app/assets/javascripts/features.js
+++ b/app/assets/javascripts/features.js
@@ -1,2 +1,19 @@
-// Place all the behaviors and hooks related to the matching controller here.
-// All this logic will automatically be available in application.js.
+function browserSupportParser() {
+  // Returns an HTMLCollection
+  let supportInfoElements = document.getElementsByClassName('browser-support-info');
+  console.log(supportInfoElements);
+
+  for (var i = 0; i < supportInfoElements.length; i++) {
+    let json = supportInfoElements.item(i).dataset.supportJson
+    console.log(json);
+    if (json === undefined) {
+      console.log("undefined JSON");
+    } else {
+      JSON.parse(supportInfoElements.item(i).dataset.supportJson);
+    }
+  };
+}
+
+ready(function () {
+  browserSupportParser();
+});

--- a/app/assets/javascripts/features.js
+++ b/app/assets/javascripts/features.js
@@ -1,19 +1,59 @@
 function browserSupportParser() {
   // Returns an HTMLCollection
   let supportInfoElements = document.getElementsByClassName('browser-support-info');
-  console.log(supportInfoElements);
+  // console.log(supportInfoElements);
 
   for (var i = 0; i < supportInfoElements.length; i++) {
-    let json = supportInfoElements.item(i).dataset.supportJson
-    console.log(json);
-    if (json === undefined) {
-      console.log("undefined JSON");
-    } else {
-      JSON.parse(supportInfoElements.item(i).dataset.supportJson);
+    let json = supportInfoElements.item(i).dataset.supportJson;
+    let item = supportInfoElements.item(i);
+    // console.log(json);
+    if (json !== undefined) {
+      parsedJson = JSON.parse(json);
+
+      // If the JSON is an array, there are multiple
+      // support objects that need to be parsed.
+      if (Array.isArray(parsedJson)) {
+        parseArraySupportObject(parsedJson, item);
+      // Otherwise, the JSON is a hash and can be parsed
+      // relatively simply.
+      } else {
+        parseHashSupportObject(parsedJson, item);
+      }
     }
   };
 }
 
+function parseHashSupportObject(json, item) {
+  jsonKeys = Object.keys(json);
+  console.log(item);
+  item.textContent = "butts";
+  item.dataset.test = "butts";
+  item.dataset.toggle = "popover";
+  item.dataset.trigger = "focus";
+  item.dataset.title = "More details";
+  item.dataset.content = "details";
+
+  console.log(json.version_added);
+  console.log(json.alternative_name);
+
+  possibleKeys = [
+    "version_added",
+    "version_removed",
+    "flags",
+    "notes",
+    "prefix",
+    "partial_implementation"
+  ];
+}
+
+function parseArraySupportObject(json) {
+  console.log(json);
+}
+
 ready(function () {
   browserSupportParser();
+  $('body').popover({
+    container: 'body',
+    selector: '[data-toggle="popover"]'
+  })
 });

--- a/app/assets/javascripts/ready.js
+++ b/app/assets/javascripts/ready.js
@@ -1,0 +1,19 @@
+/*!
+ * Run event after the DOM is ready
+ * (c) 2017 Chris Ferdinandi, MIT License, https://gomakethings.com
+ * @param  {Function} fn Callback function
+ */
+var ready = function (fn) {
+
+  // Sanity check
+  if (typeof fn !== 'function') return;
+
+  // If document is already loaded, run method
+  if (document.readyState === 'interactive' || document.readyState === 'complete') {
+    return fn();
+  }
+
+  // Otherwise, wait until document is loaded
+  document.addEventListener('DOMContentLoaded', fn, false);
+
+};

--- a/app/assets/javascripts/welcome.js
+++ b/app/assets/javascripts/welcome.js
@@ -9,11 +9,11 @@ function getJsonLocation() {
     .catch(err => { throw err });
 }
 
-window.onload = function() { 
+ready(function () {
   // Only run the function if the element exists, this way there's no
   // failure in the production environment where the JSON isn't sent to the
   // client.
   if (document.getElementById('data-json-location') !== null) {
     getJsonLocation();
   }
-};
+});

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -129,4 +129,31 @@ td.bg-unknown {
   background-color: #eee;
 }
 
+td.browser-support-info {
+  position: relative;
 
+  &.more-info-available {
+    &:hover {
+      cursor: pointer;
+    }
+
+    &::after {
+      content: "?";
+      position: absolute;
+      top: 2px;
+      right: 2px;
+    }
+  }
+}
+
+.popover {
+  max-width: 500px;
+
+  p {
+    margin-bottom: 0;
+  }
+
+  p ~ p {
+    margin-top: 8px;
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -139,6 +139,7 @@ td.browser-support-info {
 
     &::after {
       content: "?";
+      font-weight: 600;
       position: absolute;
       top: 2px;
       right: 2px;

--- a/app/helpers/features_helper.rb
+++ b/app/helpers/features_helper.rb
@@ -1,6 +1,5 @@
 module FeaturesHelper
   def version_added_parser(browser_info)
-    puts browser_info
     if browser_info.kind_of?(Array)
       version_added = browser_info[0]['version_added']
     elsif browser_info.kind_of?(Hash)

--- a/app/helpers/features_helper.rb
+++ b/app/helpers/features_helper.rb
@@ -1,5 +1,6 @@
 module FeaturesHelper
   def version_added_parser(browser_info)
+    puts browser_info
     if browser_info.kind_of?(Array)
       version_added = browser_info[0]['version_added']
     elsif browser_info.kind_of?(Hash)
@@ -9,13 +10,41 @@ module FeaturesHelper
     # it would appear false values are changed to nil by Ruby at some point
     case version_added
       when true
-        return content_tag(:td, "Yes", class: "bg-true text-center")
+        return content_tag(
+                :td,
+                "Yes",
+                class: "bg-true text-center browser-support-info",
+                data: {
+                  support_json: browser_info
+                }
+               )
       when false
-        return content_tag(:td, "No", class: "bg-false text-center")
+        return content_tag(
+                :td,
+                "No",
+                class: "bg-false text-center browser-support-info",
+                data: {
+                  support_json: browser_info
+                }
+              )
       when nil
-        return content_tag(:td, "?", class: "bg-unknown text-center")
+        return content_tag(
+                :td,
+                "?",
+                class: "bg-unknown text-center browser-support-info",
+                data: {
+                  support_json: browser_info
+                }
+              )
       else
-        return content_tag(:td, version_added, class: "bg-true text-center")
+        return content_tag(
+                :td,
+                version_added,
+                class: "bg-true text-center browser-support-info",
+                data: {
+                  support_json: browser_info
+                }
+              )
       end
   end
 end

--- a/app/helpers/features_helper.rb
+++ b/app/helpers/features_helper.rb
@@ -15,8 +15,7 @@ module FeaturesHelper
                 "Yes",
                 class: "bg-true text-center browser-support-info",
                 data: {
-                  support_json: browser_info,
-                  toggle: "popover"
+                  support_json: browser_info
                 }
                )
       when false
@@ -25,8 +24,7 @@ module FeaturesHelper
                 "No",
                 class: "bg-false text-center browser-support-info",
                 data: {
-                  support_json: browser_info,
-                  toggle: "popover"
+                  support_json: browser_info
                 }
               )
       when nil
@@ -35,8 +33,7 @@ module FeaturesHelper
                 "?",
                 class: "bg-unknown text-center browser-support-info",
                 data: {
-                  support_json: browser_info,
-                  toggle: "popover"
+                  support_json: browser_info
                 }
               )
       else
@@ -45,8 +42,7 @@ module FeaturesHelper
                 version_added,
                 class: "bg-true text-center browser-support-info",
                 data: {
-                  support_json: browser_info,
-                  toggle: "popover"
+                  support_json: browser_info
                 }
               )
       end

--- a/app/helpers/features_helper.rb
+++ b/app/helpers/features_helper.rb
@@ -15,7 +15,8 @@ module FeaturesHelper
                 "Yes",
                 class: "bg-true text-center browser-support-info",
                 data: {
-                  support_json: browser_info
+                  support_json: browser_info,
+                  toggle: "popover"
                 }
                )
       when false
@@ -24,7 +25,8 @@ module FeaturesHelper
                 "No",
                 class: "bg-false text-center browser-support-info",
                 data: {
-                  support_json: browser_info
+                  support_json: browser_info,
+                  toggle: "popover"
                 }
               )
       when nil
@@ -33,7 +35,8 @@ module FeaturesHelper
                 "?",
                 class: "bg-unknown text-center browser-support-info",
                 data: {
-                  support_json: browser_info
+                  support_json: browser_info,
+                  toggle: "popover"
                 }
               )
       else
@@ -42,7 +45,8 @@ module FeaturesHelper
                 version_added,
                 class: "bg-true text-center browser-support-info",
                 data: {
-                  support_json: browser_info
+                  support_json: browser_info,
+                  toggle: "popover"
                 }
               )
       end

--- a/public/data-test.json
+++ b/public/data-test.json
@@ -84,6 +84,22 @@
         }
       }
     },
+    "feature_with_complex_firefox": {
+      "__compat": {
+        "support": {
+          "firefox": [
+            {
+              "version_added": "21"
+            },
+            {
+              "version_added": "19",
+              "version_removed": "20",
+              "prefix": "-webkit-"
+            }
+          ]
+        }
+      }
+    },
     "standard_feature_with_description": {
       "__compat": {
         "description": "Lorem ipsum",

--- a/public/data-test.json
+++ b/public/data-test.json
@@ -84,6 +84,72 @@
         }
       }
     },
+    "feature_with_notes": {
+      "__compat": {
+        "support": {
+          "firefox": {
+            "version_added": true,
+            "notes": "This is a note"
+          }
+        }
+      }
+    },
+    "feature_with_multiple_notes": {
+      "__compat": {
+        "support": {
+          "firefox": {
+            "version_added": true,
+            "notes": [
+              "This is a note.",
+              "This is also a note."
+            ]
+          }
+        }
+      }
+    },
+    "feature_with_lots_of_data": {
+      "__compat": {
+        "support": {
+          "firefox": {
+            "version_added": true,
+            "notes": [
+              "This is a note.",
+              "This is also a note."
+            ],
+            "prefix": "-webkit-",
+            "alternative_name": "alternatively-named-feature",
+            "partial_implementation": true,
+            "flags": [
+              {
+                "type": "preference",
+                "name": "Enable Experimental Web Platform Features",
+                "value_to_set": "true"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "feature_with_flags": {
+      "__compat": {
+        "support": {
+          "firefox": {
+            "version_added": true,
+            "flags": [
+              {
+                "type": "preference",
+                "name": "Enable Experimental Web Platform Features",
+                "value_to_set": "true"
+              },
+              {
+                "type": "runtime_flag",
+                "name": "--js-enable-cookies"
+              }
+            ]
+          }
+        }
+      }
+    },
     "feature_with_complex_firefox": {
       "__compat": {
         "support": {


### PR DESCRIPTION
This PR adds support for complex support data, exposing it via a popover in the data table. This is pretty much entirely done clientside.

Here's how it looks right now, it's still a WIP:

<img width="286" alt="screen shot 2018-04-30 at 5 37 25 pm" src="https://user-images.githubusercontent.com/2977353/39455352-32b468dc-4c9d-11e8-8fbd-a27a28e7d913.png">

<img width="504" alt="screen shot 2018-04-30 at 5 37 30 pm" src="https://user-images.githubusercontent.com/2977353/39455353-32ca9922-4c9d-11e8-93a5-d2fa274788a2.png">
