### PR TITLE
Add a show page for each browser, list all new features for each release

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -60,6 +60,18 @@ $zindex-header: 1080; // This ensures the header will be above popovers/tooltips
   td.release-notes a {
     text-decoration: none;
   }
+
+  th.features-column,
+  td.features-column {
+    width: 600px;
+    max-width: 600px;
+
+    p {
+      text-overflow: ellipsis;
+      overflow: hidden;
+      white-space: nowrap;
+    }
+  }
 }
 
 .features-table {

--- a/app/controllers/browsers_controller.rb
+++ b/app/controllers/browsers_controller.rb
@@ -1,37 +1,14 @@
 class BrowsersController < ApplicationController
   def index
-    @browsers = Browser.all
-
-    @browsers.each do |browser|
-      # https://stackoverflow.com/questions/808318/sorting-a-ruby-array-of-objects-by-an-attribute-that-could-be-nil
-      # Sorts the array and leaves nil values at the end.
-      browser.releases = browser.releases.sort { |a, b| a["release_date"] && b["release_date"] ? a["release_date"] <=> b["release_date"] : a["release_date"] ? -1 : 1 }
-
-      nil_values = []
-      browser_releases_with_release_dates = []
-      browser.releases.each_with_index do |release_info, i|
-        # Collect all release dates which are nil so we can sort them
-        # separately.
-        if release_info["release_date"].nil?
-          nil_values << browser.releases[i]
-        # Collect all releases with release date values.
-        else
-          browser_releases_with_release_dates << browser.releases[i]
-        end
-      end
-
-      # Replace browser.releases with the array of releases that have valid
-      # release dates. This is a workaround means of deleting all nil values.
-      browser.releases = browser_releases_with_release_dates
-
-      # Sort the nil_values array by the version number, then append it to the
-      # browser releases.
-      VersionSorter.sort!(nil_values) { |release| release["version"] }
-      nil_values.each { |release| browser.releases.push(release) }
-    end
+    @browsers = helpers.browser_releases_sorter(Browser.all)
 
     respond_to do |format|
       format.html
     end
+  end
+
+  def show
+    @browser = Browser.find(params[:id])
+    @browser = helpers.browser_releases_sorter(@browser)
   end
 end

--- a/app/helpers/browsers_helper.rb
+++ b/app/helpers/browsers_helper.rb
@@ -1,2 +1,46 @@
 module BrowsersHelper
+  def browser_releases_sorter(browsers)
+    # Handle two main cases for the browsers value:
+    # - where only a single Browser object is passed
+    # - when an ActiveRecord Relation with multiple browsers is passed
+    if browsers.kind_of?(Browser)
+      release_sorter(browsers)
+    else
+      browsers.each do |browser|
+        release_sorter(browser)
+      end
+    end
+
+    return browsers
+  end
+
+  private
+
+  def release_sorter(browser)
+    # https://stackoverflow.com/questions/808318/sorting-a-ruby-array-of-objects-by-an-attribute-that-could-be-nil
+    # Sorts the array and leaves nil values at the end.
+    browser.releases = browser.releases.sort { |a, b| a["release_date"] && b["release_date"] ? a["release_date"] <=> b["release_date"] : a["release_date"] ? -1 : 1 }
+
+    nil_values = []
+    browser_releases_with_release_dates = []
+    browser.releases.each_with_index do |release_info, i|
+      # Collect all release dates which are nil so we can sort them
+      # separately.
+      if release_info["release_date"].nil?
+        nil_values << browser.releases[i]
+      # Collect all releases with release date values.
+      else
+        browser_releases_with_release_dates << browser.releases[i]
+      end
+    end
+
+    # Replace browser.releases with the array of releases that have valid
+    # release dates. This is a workaround means of deleting all nil values.
+    browser.releases = browser_releases_with_release_dates
+
+    # Sort the nil_values array by the version number, then append it to the
+    # browser releases.
+    VersionSorter.sort!(nil_values) { |release| release["version"] }
+    nil_values.each { |release| browser.releases.push(release) }
+  end
 end

--- a/app/helpers/features_helper.rb
+++ b/app/helpers/features_helper.rb
@@ -63,6 +63,6 @@ module FeaturesHelper
   end
 
   def browser_release_features(browser, version)
-    return Feature.where("#{browser} @> ?", {'version_added': "#{version}"}.to_json)
+    return Feature.where("#{browser} @> ?", {'version_added': "#{version}"}.to_json).select("name")
   end
 end

--- a/app/helpers/features_helper.rb
+++ b/app/helpers/features_helper.rb
@@ -61,4 +61,8 @@ module FeaturesHelper
              data: content_tag_options[:data]
            )
   end
+
+  def browser_release_features(browser, version)
+    return Feature.where("#{browser} @> ?", {'version_added': "#{version}"}.to_json)
+  end
 end

--- a/app/views/browsers/index.html.erb
+++ b/app/views/browsers/index.html.erb
@@ -24,7 +24,7 @@
           <table id="<%= "#{browser.name.downcase.gsub(' ', '_')}" %>" class="table mb-0 browser-table width-full">
             <thead>
               <tr class="text-center bg-light border-transparent rounded-top">
-                <th class="border-top-0" colspan="4"><%= browser.name %></th>
+                <th class="border-top-0" colspan="4"><%= link_to browser.name, browser_path(browser.id) %></th>
               </tr>
               <tr>
                 <th>Version</th>

--- a/app/views/browsers/show.html.erb
+++ b/app/views/browsers/show.html.erb
@@ -1,0 +1,60 @@
+<div class="container">
+  <div class="row py-4">
+    <div class="col-12">
+      <h1><%= @browser.name %></h1>
+    </div>
+  </div>
+  <div class="row">
+
+    <div class="col-12">
+      <div class="card card-no-overflow mb-4">
+        <table id="<%= "#{@browser.name.downcase.gsub(' ', '_')}" %>" class="table mb-0 browser-table width-full">
+          <thead>
+            <tr class="text-center bg-light border-transparent rounded-top">
+              <th class="border-top-0" colspan="5"><%= @browser.name %></th>
+            </tr>
+            <tr>
+              <th>Version</th>
+              <th>Status</th>
+              <th>Release date</th>
+              <th>Release notes</th>
+              <th class="features-column">Features</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @browser.releases.each_with_index do |release, i| %>
+              <tr>
+                <td><%= release['version'] %></td>
+                <td><%= release['status'] %></td>
+                <td>
+                  <% unless release['release_date'].blank? %>
+                    <%# Format dates like April 2, 2017, this is the same as long but without the leading 0 for days.%>
+                    <%= Date.parse(release['release_date']).strftime("%B %-d, %Y") %>
+                  <% end %>
+                </td>
+                <td class="release-notes">
+                  <% unless release['release_notes'].blank? %>
+                    <%= link_to "📰", release['release_notes'], title: "Release notes" %>
+                  <% end %>
+                </td>
+                <td class="features-column">
+                  <p>Features added (<%= browser_release_features(@browser.browser_id, release['version']).count %>):</p>
+
+                  <a class="btn btn-primary" data-toggle="collapse" href='<%= "#collapseReleaseFeatures#{i}" %>' role="button" aria-expanded="false" aria-controls='<%= "collapseReleaseFeatures#{i}" %>'>
+                    Toggle features
+                  </a>
+
+                  <div class="collapse" id='<%= "collapseReleaseFeatures#{i}" %>'>
+                    <% browser_release_features(@browser.browser_id, release['version']).each do |feature| %>
+                      <p><%= feature.name %></p>
+                    <% end %>
+                  </div>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,7 @@ Rails.application.routes.draw do
   match 'browsers', to: 'browsers#index', via: :get
   match 'graphs', to: 'graphs#index', via: :get
 
+  resources :browsers, only: [:show]
+
   root 'welcome#index'
 end

--- a/public/data-test.json
+++ b/public/data-test.json
@@ -6,6 +6,16 @@
           "release_date": "2018-03-13",
           "release_notes": "https://developer.mozilla.org/Firefox/Releases/59",
           "status": "current"
+        },
+        "2": {
+          "release_date": "2018-03-14",
+          "release_notes": "https://developer.mozilla.org/Firefox/Releases/59",
+          "status": "current"
+        },
+        "10": {
+          "release_date": "2018-03-15",
+          "release_notes": "https://developer.mozilla.org/Firefox/Releases/59",
+          "status": "current"
         }
       }
     }
@@ -78,7 +88,7 @@
       "__compat": {
         "support": {
           "firefox": {
-            "version_added": true,
+            "version_added": "10",
             "alternative_name": "feature_with_firefox_alternative_name"
           }
         }
@@ -88,7 +98,7 @@
       "__compat": {
         "support": {
           "firefox": {
-            "version_added": true,
+            "version_added": "1",
             "notes": "This is a note"
           }
         }


### PR DESCRIPTION
Also add a browser release sorting helper.

This is what it looks like right now:

<img width="1436" alt="screen shot 2018-05-07 at 12 07 12 pm" src="https://user-images.githubusercontent.com/2977353/39717004-37016c08-51ef-11e8-9316-9fc621ab2dd4.png">

Resolves #32 