### PR TITLE
Add random sorting for the features page.

### DIFF
--- a/app/controllers/features_controller.rb
+++ b/app/controllers/features_controller.rb
@@ -63,6 +63,11 @@ class FeaturesController < ApplicationController
     end
 
     @feature_count = features.count
+
+    if params["random"] == "true"
+      features = features.order(Arel.sql('random()'))
+    end
+
     @features = features.page(params[:page])
 
     @browsers = Rails.configuration.browsers

--- a/app/views/features/index.html.erb
+++ b/app/views/features/index.html.erb
@@ -11,6 +11,22 @@
                                 class: "form-control") %>
             </div>
 
+
+            <div class="form-group-title">
+              Sort
+            </div>
+            <div class="form-group">
+              <div class="form-check">
+                <%= check_box_tag(
+                  "random",
+                  "true",
+                  (true if params["random"].present? && params["random"] == "true"),
+                  {id: :random, class: "form-check-input"}
+                ) %>
+                <%= label_tag(:random, "Random", class: "form-check-label") %>
+              </div>
+            </div>
+
             <div class="form-group-title">
               Categories
             </div>


### PR DESCRIPTION
Resolves #38. It doesn't make the features page default to sorting by random, but random sort should be enough.