### PR TITLE
Handle version_removed property for the browser support tables.

### DIFF
--- a/app/assets/javascripts/features.js
+++ b/app/assets/javascripts/features.js
@@ -9,20 +9,23 @@ function browserSupportParser() {
     if (json !== undefined) {
       parsedJson = JSON.parse(json);
 
-      // If the JSON is an array, there are multiple
+      // If the JSON is an array of length > 1, there are multiple
       // support objects that need to be parsed.
-      if (Array.isArray(parsedJson)) {
+      if (Array.isArray(parsedJson) && parsedJson.length > 1) {
         parseArraySupportObject(parsedJson, item);
       // Otherwise, the JSON is a hash and can be parsed
       // relatively simply.
       } else {
-        item.dataset.content = parseHashSupportObject(parsedJson, item);
+        item.dataset.content = parseHashSupportObject(parsedJson[0], item);
       }
     }
   };
 }
 
 function parseHashSupportObject(json, item, partOfArray = false) {
+  // Return early if JSON is null.
+  if (json == null) { return; }
+
   jsonKeys = Object.keys(json);
   if (jsonKeys.length > 1 || partOfArray) {
     item.dataset.toggle = "popover";
@@ -35,26 +38,24 @@ function parseHashSupportObject(json, item, partOfArray = false) {
 
   let contentForPopover = new Map();
 
-  if (partOfArray) {
-    let versionInfo = '';
+  let versionInfo = '';
 
-    if (!json) {
-      versionInfo += getVersionString(null);
-    } else {
-      versionInfo += getVersionString(json.version_added);
-    }
-
-    if (json.version_removed) {
-      // We don't know when
-      if (typeof (json.version_removed) === 'boolean' && json.version_removed) {
-        versionInfo += '&nbsp;—?'
-      } else { // We know when
-        versionInfo += '&nbsp;— ' + json.version_removed;
-      }
-    }
-
-    contentForPopover.set("version_added", `<b>${versionInfo}</b>`);
+  if (!json) {
+    versionInfo += getVersionString(null);
+  } else {
+    versionInfo += getVersionString(json.version_added);
   }
+
+  if (json.version_removed) {
+    // We don't know when
+    if (typeof (json.version_removed) === 'boolean' && json.version_removed) {
+      versionInfo += '&nbsp;—?'
+    } else { // We know when
+      versionInfo += '&nbsp;— ' + json.version_removed;
+    }
+  }
+
+  contentForPopover.set("version_added", `<b>${versionInfo}</b>`);
 
   if (jsonKeys.includes('partial_implementation')) {
     contentForPopover.set("partial_implementation", "This is a partial implementation.");

--- a/app/helpers/features_helper.rb
+++ b/app/helpers/features_helper.rb
@@ -1,9 +1,14 @@
 module FeaturesHelper
   def version_added_parser(browser_info)
-    if browser_info.kind_of?(Array)
+    # Simply the parser by converting hashes to an Array of length one.
+    if (browser_info.kind_of?(Hash) || browser_info.nil?)
+      array = Array.new(1)
+      array[0] = browser_info
+      browser_info = array
+    end
+
+    unless browser_info[0].nil?
       version_added = browser_info[0]['version_added']
-    elsif browser_info.kind_of?(Hash)
-      version_added = browser_info['version_added']
     end
 
     content_tag_options = {}
@@ -48,10 +53,15 @@ module FeaturesHelper
         }
       end
 
-    if browser_info.kind_of?(Array) && browser_info[0]['partial_implementation']
+    # If the support object has partial_implementation set to true, add a
+    # CSS class to make the background yellow.
+    if !browser_info[0].nil? && browser_info[0]['partial_implementation']
       content_tag_options[:class] += " bg-partial"
-    elsif browser_info.kind_of?(Hash) && browser_info['partial_implementation']
-      content_tag_options[:class] += " bg-partial"
+    end
+
+    if !browser_info[0].nil? && browser_info[0]['version_removed'].present?
+      content_tag_options[:class] += " bg-false"
+      content_tag_options[:content] = "No"
     end
 
     return content_tag(


### PR DESCRIPTION
This resolves #36.

This also converts support object hashes to arrays as a means of simplifying the code.