### PR TITLE
Add filtering by per-browser status to the search page.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Keep a `CHANGELOG.md`. ([#45])
 - Display Travis CI badge in `README.md`. ([#47])
 - Add a 404 checker for MDN URLs, currently this is run manually and not saved or exposed in the application. ([#48])
+- Add filtering by browser status (e.g. filter down to features where Firefox is exactly `true` or where Chrome has no data) to the search page. ([#51])
 
 ### Fixed
 - Correctly handle `version_removed` property for the browser support tables. ([#43])
@@ -85,6 +86,7 @@ First tagged release, includes some basic functionality.
 [#45]: https://github.com/connorshea/mdn-compat-data-explorer/pull/45
 [#47]: https://github.com/connorshea/mdn-compat-data-explorer/pull/47
 [#48]: https://github.com/connorshea/mdn-compat-data-explorer/pull/48
+[#51]: https://github.com/connorshea/mdn-compat-data-explorer/pull/51
 
 [Unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.3.1...HEAD
 [0.3.1]: https://github.com/connorshea/mdn-compat-data-explorer/compare/v0.3.0...v0.3.1

--- a/app/controllers/features_controller.rb
+++ b/app/controllers/features_controller.rb
@@ -62,15 +62,29 @@ class FeaturesController < ApplicationController
       features = features.no_standard_track_info
     end
 
-    @feature_count = features.count
-
     if params["random"] == "true"
       features = features.order(Arel.sql('random()'))
     end
 
-    @features = features.page(params[:page])
-
     @browsers = Rails.configuration.browsers
+
+    @browsers.keys.each do |browser|
+      if params[browser] == "unknown"
+        features = features.public_send("#{browser}_nil")
+      elsif params[browser] == "true"
+        features = features.public_send("#{browser}_true")
+      elsif params[browser] == "exactly_true"
+        features = features.public_send("#{browser}_exactly_true")
+      elsif params[browser] == "false"
+        features = features.public_send("#{browser}_false")
+      elsif params[browser] == "no_data"
+        features = features.public_send("#{browser}_no_data")
+      end
+    end
+
+    @feature_count = features.count
+
+    @features = features.page(params[:page])
     
     [:qq_android, :uc_android, :uc_chinese_android, :samsunginternet_android].each do |browser|
       @browsers.delete(browser)

--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -88,5 +88,7 @@ class Feature < ApplicationRecord
            )
         .or(where( "#{browser} @> ?", {'version_added': true}.to_json))
     }
+
+    scope "#{browser}_exactly_true", -> { where( "#{browser} @> ?", {'version_added': true}.to_json) }
   end
 end

--- a/app/views/features/index.html.erb
+++ b/app/views/features/index.html.erb
@@ -124,6 +124,26 @@
                 { include_blank: true, class: "form-control form-control-sm" }
               ) %>
             </div>
+
+            <% @browsers.each do |browser_key, browser_name| %>
+              <div class="form-group">
+                <%= label_tag(browser_key, "#{browser_name} status") %>
+                <%= select_tag(
+                  browser_key,
+                  options_for_select(
+                    [
+                      ['True', true],
+                      ['Exactly true', "exactly_true"],
+                      ['False', false],
+                      ['Unknown', "unknown"],
+                      ['No info', "no_data"]
+                    ],
+                    params[browser_key]
+                  ),
+                  { include_blank: true, class: "form-control form-control-sm" }
+                ) %>
+              </div>
+            <% end %>
           </div>
 
           <div class="search-button-container">


### PR DESCRIPTION
Add filters for every browser's statuses to the search page.

<img width="359" alt="screen shot 2018-05-11 at 3 15 30 pm" src="https://user-images.githubusercontent.com/2977353/39947691-163f3a42-5530-11e8-9e60-c087619e8171.png">
