### PR TITLE
Add a "Search on GitHub" link to every feature card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Display Travis CI badge in `README.md`. ([#47])
 - Add a 404 checker for MDN URLs, currently this is run manually and not saved or exposed in the application. ([#48])
 - Add filtering by browser status (e.g. filter down to features where Firefox is exactly `true` or where Chrome has no data) to the search page. ([#51])
+- Add a "Search on GitHub" link to feature cards, it searches for the feature in the `browser-compat-data` repo. ([#53])
 
 ### Fixed
 - Correctly handle `version_removed` property for the browser support tables. ([#43])
@@ -87,6 +88,7 @@ First tagged release, includes some basic functionality.
 [#47]: https://github.com/connorshea/mdn-compat-data-explorer/pull/47
 [#48]: https://github.com/connorshea/mdn-compat-data-explorer/pull/48
 [#51]: https://github.com/connorshea/mdn-compat-data-explorer/pull/51
+[#53]: https://github.com/connorshea/mdn-compat-data-explorer/pull/53
 
 [Unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.3.1...HEAD
 [0.3.1]: https://github.com/connorshea/mdn-compat-data-explorer/compare/v0.3.0...v0.3.1

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -97,6 +97,12 @@ $zindex-header: 1080; // This ensures the header will be above popovers/tooltips
   width: 100%;
 }
 
+.feature-card-title {
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: space-between;
+}
+
 .card-no-overflow {
   overflow: hidden;
 }

--- a/app/views/features/_features_list.html.erb
+++ b/app/views/features/_features_list.html.erb
@@ -1,29 +1,38 @@
 <% features.each do |feature| %>
   <div class="card card-no-overflow my-3 feature-card feature-card-<%= feature.name.gsub('.', '-') %>">
     <div class="card-body">
-      <h5 class="card-title">
-        <span class="mr-1"><%= feature.name %></span>
-        <% if feature.standard_track? %>
-          <abbr class="icon status-standard" title="Standard. Feature is on a standard track.">
-            <%= octicon "verified", height: 16,  class: "inline right left", "aria-label": "Standard track" %>
-          </abbr>
-        <% end %>
-        <% if !feature.standard_track? && !feature.standard_track.nil? %>
-          <abbr class="icon status-nonstandard" title="Non-standard. Expect poor cross-browser support.">
-            <%= octicon "alert", height: 16,  class: "inline right left", "aria-label": "Non-standard" %>
-          </abbr>
-        <% end %>
-        <% if feature.experimental? %>
-          <abbr class="icon status-experimental" title="Experimental. Expect behavior to change in the future.">
-            <%= octicon "beaker", height: 16,  class: "inline right left", "aria-label": "Experimental" %>
-          </abbr>
-        <% end %>
-        <% if feature.deprecated? %>
-          <abbr class="icon status-deprecated" title="Deprecated. Not for use in new websites.">
-            <%= octicon "trashcan", height: 16,  class: "inline right left", "aria-label": "Deprecated" %>
-          </abbr>
-        <% end %>
-      </h5>
+      <div class="card-title feature-card-title mb-2">
+        <h5>
+          <span class="mr-1"><%= feature.name %></span>
+          <% if feature.standard_track? %>
+            <abbr class="icon status-standard" title="Standard. Feature is on a standard track.">
+              <%= octicon "verified", height: 16,  class: "inline right left", "aria-label": "Standard track" %>
+            </abbr>
+          <% end %>
+          <% if !feature.standard_track? && !feature.standard_track.nil? %>
+            <abbr class="icon status-nonstandard" title="Non-standard. Expect poor cross-browser support.">
+              <%= octicon "alert", height: 16,  class: "inline right left", "aria-label": "Non-standard" %>
+            </abbr>
+          <% end %>
+          <% if feature.experimental? %>
+            <abbr class="icon status-experimental" title="Experimental. Expect behavior to change in the future.">
+              <%= octicon "beaker", height: 16,  class: "inline right left", "aria-label": "Experimental" %>
+            </abbr>
+          <% end %>
+          <% if feature.deprecated? %>
+            <abbr class="icon status-deprecated" title="Deprecated. Not for use in new websites.">
+              <%= octicon "trashcan", height: 16,  class: "inline right left", "aria-label": "Deprecated" %>
+            </abbr>
+          <% end %>
+        </h5>
+
+        <p class="card-text feature-github-link">
+          <%= link_to "https://github.com/mdn/browser-compat-data/search?q=#{feature.name}", title: "Search on GitHub" do %>
+            <%= octicon "mark-github", height: 16,  class: "inline right left", "aria-label": "Search on GitHub" %>
+          <% end %>
+        </p>
+      </div>
+
       <% if feature.description %>
         <p class="card-text feature-description"><%= sanitize feature.description %></p>
       <% end %>

--- a/app/views/features/index.html.erb
+++ b/app/views/features/index.html.erb
@@ -125,6 +125,10 @@
               ) %>
             </div>
 
+            <div class="form-group-title">
+              Browsers
+            </div>
+
             <% @browsers.each do |browser_key, browser_name| %>
               <div class="form-group">
                 <%= label_tag(browser_key, "#{browser_name} status") %>


### PR DESCRIPTION
Resolves #52. The link searches the `browser-compat-data` repo for the feature name.

<img width="1070" alt="screen shot 2018-05-11 at 4 24 52 pm" src="https://user-images.githubusercontent.com/2977353/39949483-3c59d0b8-5538-11e8-8f1f-08b42a674699.png">

