### PR TITLE
Fix the subfeatures regex.

### DIFF
--- a/app/controllers/features_controller.rb
+++ b/app/controllers/features_controller.rb
@@ -91,7 +91,7 @@ class FeaturesController < ApplicationController
     @feature = Feature.friendly.find(params[:slug])
     @browsers = get_browsers
 
-    @subfeatures = Feature.where("name ~* ?", "^#{@feature.name}.*").where.not(slug: params[:slug])
+    @subfeatures = Feature.where("name ~ ?", "^#{@feature.name}\\..*").where.not(slug: params[:slug])
 
     parent_feature_name = @feature.name.split(/\./)
     parent_feature_name.pop


### PR DESCRIPTION
This fixes the regex so that it literally matches a dot after the current feature name.

This way, `api.Animation` will have `api.Animation.cancel` as a subfeature, but not `api.AnimationEffect`.

Fixes #68.