### PR TITLE
Upgrade the mdn-browser-compat-data package to v0.0.61.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 ### Changed
 - Upgrade the dataset to `0.0.55`. ([#220])
+- Fix deprecation warnings from FactoryBot. ([#222])
+- Upgrade Bundler to v1.17.2. ([#223])
+- Upgrade the dataset to `0.0.61`. ([#224])
 
 ## [0.7.0] - 2018-11-11
 ### Changed
@@ -152,6 +155,9 @@ First tagged release, includes some basic functionality.
 [#127]: https://github.com/connorshea/mdn-compat-data-explorer/pull/127
 [#188]: https://github.com/connorshea/mdn-compat-data-explorer/pull/188
 [#220]: https://github.com/connorshea/mdn-compat-data-explorer/pull/220
+[#222]: https://github.com/connorshea/mdn-compat-data-explorer/pull/222
+[#223]: https://github.com/connorshea/mdn-compat-data-explorer/pull/223
+[#224]: https://github.com/connorshea/mdn-compat-data-explorer/pull/224
 
 [Unreleased]: https://github.com/connorshea/mdn-compat-data-explorer/compare/v0.7.0...HEAD
 [0.7.0]: https://github.com/connorshea/mdn-compat-data-explorer/compare/v0.6.0...v0.7.0

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,7 +12,7 @@ module MdnCompatDataExplorer
     config.load_defaults 5.2
 
     # Set the version of the MDN BCD Package
-    config.mdn_bcd_version = '0.0.55'
+    config.mdn_bcd_version = '0.0.61'
 
     Rails.application.config.assets.configure do |env|
       AutoprefixerRails.uninstall env

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "chart.js": "^2.7.2",
-    "mdn-browser-compat-data": "0.0.55"
+    "mdn-browser-compat-data": "0.0.61"
   },
   "scripts": {
     "build": "node ./lib/build.js"

--- a/yarn.lock
+++ b/yarn.lock
@@ -35,10 +35,10 @@ extend@3.0.2:
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
-mdn-browser-compat-data@0.0.55:
-  version "0.0.55"
-  resolved "https://registry.yarnpkg.com/mdn-browser-compat-data/-/mdn-browser-compat-data-0.0.55.tgz#cf91196674468c54a58cd2540880c41637d0c56a"
-  integrity sha512-JH+LPWU9pgLcxm8p7wtc32N7+xaDPGvSCVpYXiVkYaOAice2Inb7NpwywEL4JMlYgdCxtlj886s039XQQ0pS0g==
+mdn-browser-compat-data@0.0.61:
+  version "0.0.61"
+  resolved "https://registry.yarnpkg.com/mdn-browser-compat-data/-/mdn-browser-compat-data-0.0.61.tgz#bfc091c9fdc441c182afe7b0f046cc1465b65c36"
+  integrity sha512-EWHhyN1KUoMCwge0S5bcmBoTj7e+yWBfUuaoVzFFG4vEUmOwwCSkbuphheD96ublo5M2XKa1g82xJhyAjARx3A==
   dependencies:
     extend "3.0.2"
 


### PR DESCRIPTION
Upgrade the dataset from v0.0.55 to v0.0.61 (the latest version).

https://github.com/mdn/browser-compat-data/releases/tag/v0.0.61

The reason this took so long was because it had over 10k features, and Heroku's free tier only allows 10k rows in Postgres, so I couldn't actually deploy anything past v0.0.45 :D 